### PR TITLE
Fix changed_when and make directories configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Ansible Role: Dotfiles
 
 Installs a set of dotfiles from a given Git repostiory. By default it will use my [dotfiles repo][dotfiles] but you can easily change it to use yours.
-Works for all dotfile repos that follow the [stow][stow] format.
+Works for all dotfile repos that follow the [stow][stow] format ([blog post](https://brandon.invergo.net/news/2012-05-26-using-gnu-stow-to-manage-your-dotfiles.html)).
 
 ## Usage
 
-1. Change the `dotfiles_repo` variable in `defaults/main.yml` to point to your dotfiles repo
+1. Change the `dotfiles_repo` variable to point to your dotfiles repo
 2. Create a playbook with this Role
 3. Run the playbook
 
@@ -19,8 +19,7 @@ None
 ---
 - hosts: localhost
   roles:
-    - { role: mariuskimmina.dotfiles }
-  become: true
+    - { role: idolize.dotfiles }
 ```
 
 
@@ -30,11 +29,15 @@ Fully tested on:
 
 * Fedora 36
 * Ubuntu 20.04
+* macOS 13.4.1
 
 ## Credits
 
+Forked from: https://github.com/mariuskimmina/ansible-role-dotfiles
+
 Inspired by: https://github.com/geerlingguy/ansible-role-dotfiles
+
 The main difference between the original project and this one is the usage of [stow][stow].
 
 [stow]: https://www.gnu.org/software/stow/
-[dotfiles]: https://github.com/mariuskimmina/.dotfiles
+[dotfiles]: https://github.com/idolize/dotfiles

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Fully tested on:
 
 * Fedora 36
 * Ubuntu 20.04
-* macOS 13.4.1
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ None
 - hosts: localhost
   roles:
     - { role: mariuskimmina.dotfiles }
+  become: true
 ```
 
 
@@ -38,4 +39,4 @@ Inspired by: https://github.com/geerlingguy/ansible-role-dotfiles
 The main difference between the original project and this one is the usage of [stow][stow].
 
 [stow]: https://www.gnu.org/software/stow/
-[dotfiles]: https://github.com/idolize/dotfiles
+[dotfiles]: https://github.com/mariuskimmina/.dotfiles

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ None
 ---
 - hosts: localhost
   roles:
-    - { role: idolize.dotfiles }
+    - { role: mariuskimmina.dotfiles }
 ```
 
 
@@ -32,8 +32,6 @@ Fully tested on:
 * macOS 13.4.1
 
 ## Credits
-
-Forked from: https://github.com/mariuskimmina/ansible-role-dotfiles
 
 Inspired by: https://github.com/geerlingguy/ansible-role-dotfiles
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Works for all dotfile repos that follow the [stow][stow] format ([blog post](htt
 
 ## Usage
 
-1. Change the `dotfiles_repo` variable to point to your dotfiles repo
+1. Change the `dotfiles_repo` variable in `defaults/main.yml` to point to your dotfiles repo
 2. Create a playbook with this Role
 3. Run the playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 dotfiles_repo: "https://github.com/mariuskimmina/.dotfiles.git"
 dotfiles_repo_version: main
 dotfiles_repo_accept_hostkey: false
-dotfiles_repo_local_destination: "~/dotfiles"
-dotfiles_home: "~/"
+dotfiles_repo_local_destination: "{{ ansible_env.HOME }}/dotfiles"
+dotfiles_home: "{{ ansible_env.HOME }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dotfiles_repo: "https://github.com/mariuskimmina/.dotfiles.git"
+dotfiles_repo: "https://github.com/idolize/dotfiles"
 dotfiles_repo_version: main
 dotfiles_repo_accept_hostkey: false
 dotfiles_repo_local_destination: "~/dotfiles"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dotfiles_repo: "https://github.com/idolize/dotfiles"
+dotfiles_repo: "https://github.com/mariuskimmina/.dotfiles.git"
 dotfiles_repo_version: main
 dotfiles_repo_accept_hostkey: false
 dotfiles_repo_local_destination: "~/dotfiles"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,5 @@
 dotfiles_repo: "https://github.com/mariuskimmina/.dotfiles.git"
 dotfiles_repo_version: main
 dotfiles_repo_accept_hostkey: false
+dotfiles_repo_local_destination: "~/dotfiles"
+dotfiles_home: "~/"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,12 +18,6 @@ galaxy_info:
     - name: GenericLinux
       versions:
         - all
-    - name: macOS
-      versions:
-        - all
-    - name: MacOSX
-      versions:
-        - all
   galaxy_tags:
     - development
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,24 +3,27 @@ dependencies: []
 
 galaxy_info:
   role_name: dotfiles
-  author: mariuskimmina
+  author: idolize
   description: Dotfile installation for UNIX/Linux using stow.
   company: None
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.2
+  min_ansible_version: "2.2"
   platforms:
     - name: GenericUNIX
       versions:
         - all
-        - any
     - name: GenericBSD
       versions:
         - all
-        - any
     - name: GenericLinux
       versions:
         - all
-        - any
+    - name: macOS
+      versions:
+        - all
+    - name: MacOSX
+      versions:
+        - all
   galaxy_tags:
     - development
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ dependencies: []
 
 galaxy_info:
   role_name: dotfiles
-  author: idolize
+  author: mariuskimmina
   description: Dotfile installation for UNIX/Linux using stow.
   company: None
   license: "license (BSD, MIT)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,7 @@
       - stow
       - git
     state: present
-  # https://stackoverflow.com/a/63734604/2359478
-  become: "{{ 'false' if ansible_pkg_mgr == 'brew' else 'true' }}"
+  become: "{{ 'false' if ansible_pkg_mgr == 'homebrew' else 'true' }}"
 
 - name: Ensure dotfiles repository is cloned locally
   ansible.builtin.git:
@@ -34,7 +33,9 @@
 
 - name: Deploy dotfiles
   with_items: '{{ files.files }}'
-  # https://phelipetls.github.io/posts/introduction-to-ansible/#stow
-  ansible.builtin.command: stow --target={{ dotfiles_home }} {{ item.path | basename }} --verbose=2
+  ansible.builtin.command:
+    cmd: stow --target={{ dotfiles_home }} {{ item.path | basename }} --verbose=2
+    chdir: "{{ dotfiles_repo_local_destination }}"
+  register: result
   changed_when: 'result.stderr is search("LINK: ")'
   become: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,8 @@
       - stow
       - git
     state: present
-  become: true
+  # https://stackoverflow.com/a/63734604/2359478
+  become: "{{ 'false' if ansible_pkg_mgr == 'brew' else 'true' }}"
 
 - name: Ensure dotfiles repository is cloned locally
   ansible.builtin.git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,51 +1,31 @@
 ---
-- name: Ensure git is installed (Fedora)
-  ansible.builtin.dnf:
-    name: git
-    state: present
-  when:
-    - ansible_os_family == 'RedHat'
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  when: ansible_pkg_mgr == 'apt'
+  changed_when: false
   become: true
 
-- name: Ensure git is installed (Ubuntu)
-  ansible.builtin.apt:
-    name: git
+- name: Install stow and git
+  ansible.builtin.package:
+    name:
+      - stow
+      - git
     state: present
-  when:
-    - ansible_os_family == 'Debian'
   become: true
 
 - name: Ensure dotfiles repository is cloned locally
-  vars:
-    user_home: "{{ lookup('env', 'HOME') }}"
   ansible.builtin.git:
     repo: "{{ dotfiles_repo }}"
-    dest: "{{ user_home }}/.dotfiles"
+    dest: "{{ dotfiles_repo_local_destination }}"
     version: "{{ dotfiles_repo_version }}"
     accept_hostkey: "{{ dotfiles_repo_accept_hostkey }}"
   become: false
 
-- name: Ensure Stow installed (Ubuntu)
-  ansible.builtin.apt:
-    name: stow
-    state: present
-  when:
-    - ansible_os_family == 'Debian'
-  become: true
-
-- name: Ensure Stow installed (Fedora)
-  ansible.builtin.dnf:
-    name: stow
-    state: present
-  when:
-    - ansible_os_family == 'RedHat'
-  become: true
-
 - name: Build directories list
-  vars:
-    user_home: "{{ lookup('env', 'HOME') }}"
   ansible.builtin.find:
-    paths: ["{{ user_home }}/.dotfiles"]
+    paths: ["{{ dotfiles_repo_local_destination }}"]
     recurse: no
     file_type: directory
   register: files
@@ -53,11 +33,6 @@
 
 - name: Deploy dotfiles
   with_items: '{{ files.files }}'
-  vars:
-    user_home: "{{ lookup('env', 'HOME') }}"
-  environment:
-    STOW_DIR: "{{ user_home }}/.dotfiles"
-  ansible.builtin.shell: |
-    stow {{ item.path | basename }}
+  ansible.builtin.command: stow --target={{ dotfiles_home }} {{ item.path | basename }}
   changed_when: false
   become: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
 
 - name: Deploy dotfiles
   with_items: '{{ files.files }}'
-  ansible.builtin.command: stow --target={{ dotfiles_home }} {{ item.path | basename }}
-  changed_when: false
+  # https://phelipetls.github.io/posts/introduction-to-ansible/#stow
+  ansible.builtin.command: stow --target={{ dotfiles_home }} {{ item.path | basename }} --verbose=2
+  changed_when: 'result.stderr is search("LINK: ")'
   become: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
       - stow
       - git
     state: present
-  become: "{{ 'false' if ansible_pkg_mgr == 'homebrew' else 'true' }}"
+  become: true
 
 - name: Ensure dotfiles repository is cloned locally
   ansible.builtin.git:


### PR DESCRIPTION
I made a few enhancements and simplifications I think would be worth upstreaming if you're willing:

1. Switched to `ansible.builtin.package` module instead of OS-specific installers
2. ~~Added support for macOS (I have tested this and it is working on macOS 13.4.1 with homebrew 4.1.13) by setting `become` to false when using homebrew~~ Edit removed in https://github.com/mariuskimmina/ansible-role-dotfiles/pull/1/commits/20bd095ff27e10e157c83df2a89dd365e400d97d
3. Instead of hardcoding `changed_when` to false, I've added a check to properly detect when something has changed
4. Finally, (inspired by [Footur's fork](https://github.com/Footur/ansible-role-dotfiles)), I also made the repo clone and destination directories configurable via variables

None of these changes (except maybe `changed_when`) are breaking changes - everything should still work the same as before for existing users.